### PR TITLE
Add explicit 1.0.0-SNAPSHOT versions to POMs

### DIFF
--- a/light-lexer/pom.xml
+++ b/light-lexer/pom.xml
@@ -13,6 +13,7 @@
   </parent>
 
   <artifactId>light-lexer</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>bundle</packaging>
 
   <name>DAISY Pipeline 2 module :: Light Lexer</name>

--- a/nlp-utils/break-detection/pom.xml
+++ b/nlp-utils/break-detection/pom.xml
@@ -13,6 +13,7 @@
   </parent>
 
   <artifactId>break-detection</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>bundle</packaging>
 
   <name>DAISY Pipeline 2 module :: Break Detection</name>

--- a/nlp-utils/lexing/pom.xml
+++ b/nlp-utils/lexing/pom.xml
@@ -13,6 +13,7 @@
   </parent>
 
   <artifactId>lexing</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>bundle</packaging>
 
   <name>DAISY Pipeline 2 module :: Lexing API</name>

--- a/nlp-utils/nlp-common/pom.xml
+++ b/nlp-utils/nlp-common/pom.xml
@@ -13,6 +13,7 @@
   </parent>
 
   <artifactId>nlp-common</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>bundle</packaging>
 
   <name>DAISY Pipeline 2 module :: NLP API</name>

--- a/omnilang-lexer/pom.xml
+++ b/omnilang-lexer/pom.xml
@@ -13,6 +13,7 @@
   </parent>
 
   <artifactId>omnilang-lexer</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>bundle</packaging>
 
   <name>DAISY Pipeline 2 module :: Omni-lingual Lexer</name>

--- a/ruled-lexer/pom.xml
+++ b/ruled-lexer/pom.xml
@@ -13,6 +13,7 @@
   </parent>
 
   <artifactId>ruled-lexer</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>bundle</packaging>
 
   <name>DAISY Pipeline 2 module :: Rule-based Lexer</name>


### PR DESCRIPTION
Otherwise, the version is inherited from the parent POM, currently at `1.8-SNAPSHOT`
