### PR TITLE
Prefix NLP project names with `nlp`

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -20,7 +20,7 @@
     <dependencies>
       <dependency>
         <groupId>org.daisy.pipeline.modules</groupId>
-        <artifactId>break-detection</artifactId>
+        <artifactId>nlp-break-detection</artifactId>
         <version>1.0.0-SNAPSHOT</version>
       </dependency>
       <dependency>
@@ -35,12 +35,12 @@
       </dependency>
       <dependency>
         <groupId>org.daisy.pipeline.modules</groupId>
-        <artifactId>lexing</artifactId>
+        <artifactId>nlp-lexing</artifactId>
         <version>1.0.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.daisy.pipeline.modules</groupId>
-        <artifactId>light-lexer</artifactId>
+        <artifactId>nlp-light-lexer</artifactId>
         <version>1.0.0-SNAPSHOT</version>
       </dependency>
       <dependency>
@@ -50,12 +50,12 @@
       </dependency>
       <dependency>
         <groupId>org.daisy.pipeline.modules</groupId>
-        <artifactId>omnilang-lexer</artifactId>
+        <artifactId>nlp-omnilang-lexer</artifactId>
         <version>1.0.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.daisy.pipeline.modules</groupId>
-        <artifactId>ruled-lexer</artifactId>
+        <artifactId>nlp-ruled-lexer</artifactId>
         <version>1.0.0-SNAPSHOT</version>
       </dependency>
       <dependency>

--- a/light-lexer/pom.xml
+++ b/light-lexer/pom.xml
@@ -31,7 +31,7 @@
     </dependency>
     <dependency>
       <groupId>org.daisy.pipeline.modules</groupId>
-      <artifactId>lexing</artifactId>
+      <artifactId>nlp-lexing</artifactId>
     </dependency>
   </dependencies>
 

--- a/nlp-utils/break-detection/pom.xml
+++ b/nlp-utils/break-detection/pom.xml
@@ -12,7 +12,7 @@
     <relativePath>../../parent</relativePath>
   </parent>
 
-  <artifactId>break-detection</artifactId>
+  <artifactId>nlp-break-detection</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>bundle</packaging>
 
@@ -59,7 +59,7 @@
    <!-- Lexing Services interface -->
    <dependency>
      <groupId>org.daisy.pipeline.modules</groupId>
-     <artifactId>lexing</artifactId>
+     <artifactId>nlp-lexing</artifactId>
    </dependency>
 
   </dependencies>

--- a/nlp-utils/lexing/pom.xml
+++ b/nlp-utils/lexing/pom.xml
@@ -12,7 +12,7 @@
     <relativePath>../../parent</relativePath>
   </parent>
 
-  <artifactId>lexing</artifactId>
+  <artifactId>nlp-lexing</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>bundle</packaging>
 

--- a/omnilang-lexer/pom.xml
+++ b/omnilang-lexer/pom.xml
@@ -12,7 +12,7 @@
     <relativePath>../parent</relativePath>
   </parent>
 
-  <artifactId>omnilang-lexer</artifactId>
+  <artifactId>nlp-omnilang-lexer</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>bundle</packaging>
 
@@ -31,7 +31,7 @@
     </dependency>
     <dependency>
       <groupId>org.daisy.pipeline.modules</groupId>
-      <artifactId>lexing</artifactId>
+      <artifactId>nlp-lexing</artifactId>
     </dependency>
   </dependencies>
 

--- a/ruled-lexer/pom.xml
+++ b/ruled-lexer/pom.xml
@@ -12,7 +12,7 @@
     <relativePath>../parent</relativePath>
   </parent>
 
-  <artifactId>ruled-lexer</artifactId>
+  <artifactId>nlp-ruled-lexer</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>bundle</packaging>
 
@@ -35,7 +35,7 @@
     </dependency>
     <dependency>
       <groupId>org.daisy.pipeline.modules</groupId>
-      <artifactId>lexing</artifactId>
+      <artifactId>nlp-lexing</artifactId>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Given these projects are all under the common `org.daisy.pipeline.modules` group, prefixing NLP-related project names with `nlp-` would help easily identifying them.

It's also consistent with the unformal naming conventions of other module (e.g. TTS, audio, etc).
