### PR TITLE
Fixes pipeline-mod-tts's issue #7

### DIFF
--- a/dtbook-break-detection/src/main/resources/xml/library.xpl
+++ b/dtbook-break-detection/src/main/resources/xml/library.xpl
@@ -24,7 +24,7 @@
       <p:with-option name="ensure-word-before" select="'acronym,span,linenum,pagenum,samp,noteref,abbr,acronym,br'"/>
       <p:with-option name="ensure-word-after" select="'acronym,span,linenum,pagenum,samp,noteref,abbr,acronym,br'"/>
       <p:with-option name="can-contain-sentences" select="'address,author,notice,prodnote,sidebar,line,em,strong,dfn,kdb,code,samp,cite,abbr,acronym,sub,sup,span,bdo,q,p,doctitle,docauthor,levelhd,hd,h1,h2,h3,h4,h5,h6,dt,dd,li,lic,caption,th,td,bridgehead,byline,covertitle,epigraph,dateline,a'"/>
-      <p:with-option name="special-sentences" select="'pagenum,prodnote,annoref,noteref,linenum'"/>
+      <p:with-option name="special-sentences" select="'pagenum,annoref,noteref,linenum'"/>
       <p:with-option name="output-ns" select="'http://www.daisy.org/z3986/2005/dtbook/'"/>
       <p:with-option name="output-word-tag" select="'w'"/>
       <p:with-option name="output-sentence-tag" select="'sent'"/>

--- a/nlp-utils/break-detection/src/main/resources/xml/break-and-reshape.xpl
+++ b/nlp-utils/break-detection/src/main/resources/xml/break-and-reshape.xpl
@@ -108,8 +108,9 @@
     </p:documentation>
   </p:output>
 
-  <!-- The tags are chosen to not conflict with other elements as the
-       namespace may not be used in the XSLT scripts. -->
+  <!-- The tags are chosen to not conflict with other elements since
+       the namespace is not always used in the XSLT scripts, which
+       otherwise helps distinguish temporary tags from the others. -->
   <p:variable name="tmp-ns" select="'http://www.daisy.org/ns/pipeline/tmp'"/>
   <p:variable name="tmp-word-tag" select="'ww'"/>
   <p:variable name="tmp-sentence-tag" select="'ss'"/>

--- a/nlp-utils/break-detection/src/main/resources/xml/distribute-sentences.xsl
+++ b/nlp-utils/break-detection/src/main/resources/xml/distribute-sentences.xsl
@@ -11,6 +11,8 @@
   <xsl:param name="tmp-sentence-tag"/>
   <xsl:param name="can-contain-sentences"/>
 
+  <xsl:variable name="ok-parent-list" select="concat(',', $can-contain-sentences, ',')"/>
+
   <!-- Copy the document until a sentence is found. -->
 
   <xsl:template match="@*|node()" priority="1">
@@ -20,56 +22,64 @@
   </xsl:template>
 
   <xsl:template match="*[local-name() = $tmp-sentence-tag]" priority="2">
-    <xsl:apply-templates select="." mode="create-sentence">
-      <xsl:with-param name="lang" select="@xml:lang"/>
-    </xsl:apply-templates>
-  </xsl:template>
-
-  <!-- Keep the sentence where it is, if possible. Otherwise split it. -->
-
-  <xsl:variable name="ok-parent-list" select="concat(',', $can-contain-sentences, ',')"/>
-  <xsl:template match="node()[contains($ok-parent-list, concat(',', local-name(..), ','))]"
-		mode="create-sentence" priority="3">
-    <xsl:param name="lang" select="''"/>
     <xsl:choose>
-      <xsl:when test="local-name() = $tmp-sentence-tag">
-	<xsl:copy-of select="."/> <!-- including the <tmp:word> nodes and @xml:lang if any. -->
+      <xsl:when test="contains($ok-parent-list, concat(',', local-name(..), ','))">
+	<xsl:call-template name="new-sent-on-top-of-children">
+	  <!-- @xml:lang comes from the Java detection -->
+	  <xsl:with-param name="lang" select="@xml:lang"/>
+	</xsl:call-template>
       </xsl:when>
       <xsl:otherwise>
-	<xsl:element name="{$tmp-sentence-tag}" namespace="{$tmp-ns}">
-	  <xsl:if test="$lang != ''">
-	    <xsl:attribute namespace="http://www.w3.org/XML/1998/namespace" name="lang">
-	      <xsl:value-of select="$lang"/>
-	    </xsl:attribute>
-	  </xsl:if>
-	  <xsl:copy-of select="."/> <!-- including the <tmp:word> nodes. -->
-	</xsl:element>
+	<xsl:apply-templates select="node()" mode="split-sentence">
+	  <xsl:with-param name="lang" select="@xml:lang"/>
+	</xsl:apply-templates>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
 
-  <xsl:template match="*[local-name() = $tmp-word-tag]" mode="create-sentence" priority="2">
+  <xsl:template match="node()[contains($ok-parent-list, concat(',', local-name(.), ','))]"
+		mode="split-sentence" priority="3">
+    <xsl:param name="lang" select="''"/>
+    <xsl:copy>
+      <xsl:copy-of select="@*"/>
+      <xsl:call-template name="new-sent-on-top-of-children">
+	<xsl:with-param name="lang" select="if (@xml:lang) then @xml:lang else $lang"/>
+      </xsl:call-template>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Sentences forbidden here: let us try the insertion inside the children. -->
+  <xsl:template match="node()" mode="split-sentence" priority="1">
+    <xsl:param name="lang" select="''"/>
+    <xsl:copy>
+      <xsl:copy-of select="@*"/>
+      <xsl:apply-templates select="node()" mode="split-sentence">
+	<xsl:with-param name="lang" select="if (@xml:lang) then @xml:lang else $lang"/>
+      </xsl:apply-templates>
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template match="*[local-name() = $tmp-word-tag]" mode="split-sentence" priority="2">
     <xsl:param name="lang" select="''"/>
     <xsl:copy-of select="node()"/> <!-- ignore the tmp:word -->
   </xsl:template>
 
-  <xsl:template match="*[local-name() = $tmp-sentence-tag]" mode="create-sentence" priority="2">
+  <xsl:template match="*[local-name() = $tmp-sentence-tag]" mode="split-sentence" priority="2">
     <xsl:param name="lang" select="''"/>
-    <!-- Inserting sentences is forbidden here. Let's try in the children. -->
-    <xsl:apply-templates select="node()" mode="create-sentence">
-      <xsl:with-param name="lang" select="$lang"/>
-    </xsl:apply-templates>
+    <!-- Should not happen. -->
+    <xsl:copy-of select="node()"/>
   </xsl:template>
 
-  <xsl:template match="node()" mode="create-sentence" priority="1">
+  <xsl:template name="new-sent-on-top-of-children">
     <xsl:param name="lang" select="''"/>
-    <!-- Inserting sentences is forbidden here. Let's try in the children -->
-    <xsl:copy>
-      <xsl:copy-of select="@*"/>
-      <xsl:apply-templates select="node()" mode="create-sentence">
-	<xsl:with-param name="lang" select="$lang"/>
-      </xsl:apply-templates>
-    </xsl:copy>
+    <xsl:element name="{$tmp-sentence-tag}" namespace="{$tmp-ns}">
+      <xsl:if test="$lang != ''">
+	<xsl:attribute namespace="http://www.w3.org/XML/1998/namespace" name="lang">
+	  <xsl:value-of select="$lang"/>
+	</xsl:attribute>
+      </xsl:if>
+      <xsl:copy-of select="node()"/> <!-- including the <tmp:word> nodes. -->
+    </xsl:element>
   </xsl:template>
 
 </xsl:stylesheet>

--- a/nlp-utils/break-detection/src/main/resources/xml/reshape.xpl
+++ b/nlp-utils/break-detection/src/main/resources/xml/reshape.xpl
@@ -31,7 +31,11 @@
   <!-- Distribute some sentences to prevent them from having parents
        not compliant with the format. -->
   <p:xslt name="distribute">
-    <p:with-param name="can-contain-sentences" select="$can-contain-sentences"/>
+    <!-- The output-sentence-tag is added so as to accept words which
+         are children of a temporary sentence which is in turn the
+         child of an existing sentence. -->
+    <p:with-param name="can-contain-sentences"
+		  select="concat($can-contain-sentences, ',', $output-sentence-tag)"/>
     <p:with-param name="tmp-word-tag" select="$tmp-word-tag"/>
     <p:with-param name="tmp-sentence-tag" select="$tmp-sentence-tag"/>
     <p:with-param name="tmp-ns" select="$tmp-ns"/>
@@ -52,6 +56,7 @@
     <p:with-param name="word-attr" select="$word-attr"/>
     <p:with-param name="word-attr-val" select="$word-attr-val"/>
     <p:with-param name="output-ns" select="$output-ns"/>
+    <p:with-param name="output-subsentence-tag" select="$output-subsentence-tag"/>
     <p:input port="stylesheet">
       <p:document href="create-valid-breaks.xsl"/>
     </p:input>


### PR DESCRIPTION
- Different way of dealing with the existing sentences and words so as to ensure that they will be kept if they encapsulate the boundaries found by the lexers;
- The prosody problem is fixed by distributing the sentences over an upper level than before (when it is forbidden to create a sentence where the lexer wants it to be).
- Removed prodnotes from the list of 'special-sentences' (not part of issue #7)
