### PR TITLE
New NLP option to comply with the DTBook spec regarding sent positioning

### DIFF
--- a/dtbook-break-detection/src/main/resources/xml/library.xpl
+++ b/dtbook-break-detection/src/main/resources/xml/library.xpl
@@ -19,11 +19,23 @@
 
     <p:import href="http://www.daisy.org/pipeline/modules/nlp-break-detection/library.xpl" />
 
+
+    <!-- The 'can-contain-sentences' covers almost all possible
+         cases. We don't usually need to make a special case for nodes
+         that cannot be containED by sentences because those nodes are
+         children of nodes that cannot contain sentences,
+         e.g. headings are children of levels, which cannot contain
+         sentences, thus there is no way to insert 'sent' between
+         levels and headings. So most of the $cannot-be-sentence-child
+         are redundant, but some are necessary nonetheless
+         (e.g. linenum and epigraph). -->
+
     <px:break-and-reshape name="generic">
       <p:with-option name="inline-tags" select="'acronym,em,strong,a,abbr,dfn,linenum,pagenum,samp,span,sup,sub,w,noteref,br'"/>
       <p:with-option name="ensure-word-before" select="'acronym,span,linenum,pagenum,samp,noteref,abbr,acronym,br'"/>
       <p:with-option name="ensure-word-after" select="'acronym,span,linenum,pagenum,samp,noteref,abbr,acronym,br'"/>
       <p:with-option name="can-contain-sentences" select="'address,author,notice,prodnote,sidebar,line,em,strong,dfn,kdb,code,samp,cite,abbr,acronym,sub,sup,span,bdo,q,p,doctitle,docauthor,levelhd,hd,h1,h2,h3,h4,h5,h6,dt,dd,li,lic,caption,th,td,bridgehead,byline,covertitle,epigraph,dateline,a'"/>
+      <p:with-option name="cannot-be-sentence-child" select="'linenum,epigraph,td,th,tr,tfoot,thead,tbody,colgroup,col,list,li,lic,table,bridgehead,blockquote,dl,dd,div,title,author,sidebar,note,annotation,byline,dateline,linegroup,poem,p,doctitle,docauthor,covertitle,h1,h2,h3,h4,h5,h6,hd'"/>
       <p:with-option name="special-sentences" select="'pagenum,annoref,noteref,linenum'"/>
       <p:with-option name="output-ns" select="'http://www.daisy.org/z3986/2005/dtbook/'"/>
       <p:with-option name="output-word-tag" select="'w'"/>

--- a/nlp-utils/break-detection/src/main/resources/xml/break-and-reshape.xpl
+++ b/nlp-utils/break-detection/src/main/resources/xml/break-and-reshape.xpl
@@ -16,6 +16,13 @@
     </p:documentation>
   </p:option>
 
+  <p:option name="cannot-be-sentence-child" required="false" select="''">
+    <p:documentation>
+      Comma-separated list of elements that cannot be contained by
+      sentence elements.
+    </p:documentation>
+  </p:option>
+
   <p:option name="special-sentences" required="false" select="''">
     <p:documentation>
       Comma-separated list of elements that cannot contain sentence
@@ -142,6 +149,7 @@
 
   <px:reshape name="reshape">
     <p:with-option name="can-contain-sentences" select="$can-contain-sentences"/>
+    <p:with-option name="cannot-be-sentence-child" select="$cannot-be-sentence-child"/>
     <p:with-option name="special-sentences" select="$special-sentences"/>
     <p:with-option name="output-word-tag" select="$output-word-tag"/>
     <p:with-option name="output-sentence-tag" select="$output-sentence-tag"/>

--- a/nlp-utils/break-detection/src/main/resources/xml/reshape.xpl
+++ b/nlp-utils/break-detection/src/main/resources/xml/reshape.xpl
@@ -9,6 +9,7 @@
   <p:import href="http://xmlcalabash.com/extension/steps/library-1.0.xpl"/>
 
   <p:option name="can-contain-sentences" required="true"/>
+  <p:option name="cannot-be-sentence-child" required="false" select="''"/>
   <p:option name="special-sentences" required="false" select="''"/>
   <p:option name="output-word-tag" required="true"/>
   <p:option name="output-sentence-tag" required="true"/>
@@ -40,6 +41,7 @@
          child of an existing sentence. -->
     <p:with-param name="can-contain-sentences"
 		  select="concat($can-contain-sentences, ',', $output-sentence-tag)"/>
+    <p:with-param name="cannot-be-sentence-child" select="$cannot-be-sentence-child"/>
     <p:with-param name="tmp-word-tag" select="$tmp-word-tag"/>
     <p:with-param name="tmp-sentence-tag" select="$tmp-sentence-tag"/>
     <p:with-param name="tmp-ns" select="$tmp-ns"/>

--- a/nlp-utils/break-detection/src/main/resources/xml/split-around-skippable.xsl
+++ b/nlp-utils/break-detection/src/main/resources/xml/split-around-skippable.xsl
@@ -85,7 +85,7 @@
 	  <xsl:when test="count(current-group()) = 1 and local-name(current-group()[1]) = $output-subsentence-tag">
 	    <xsl:copy>
 	      <xsl:copy-of select="@*"/>
-	      <xsl:apply-templates select="current-group()[1]" mode="add-id">
+	      <xsl:apply-templates select="current-group()[self::*][1]" mode="add-id">
 		<xsl:with-param name="prefix" select="'sub'"/>
 	      </xsl:apply-templates>
 	      <xsl:apply-templates select="current-group()/node()" mode="copy"/>
@@ -94,8 +94,8 @@
 	  <!-- General case. -->
 	  <xsl:otherwise>
 	    <xsl:element name="{$output-subsentence-tag}" namespace="{$output-ns}">
-	      <xsl:apply-templates select="current-group()[1]" mode="add-id">
-		<xsl:with-param name="prefix" select="'sub'"/>
+	      <xsl:apply-templates select="current-group()[self::*][1]" mode="add-id">
+	      	<xsl:with-param name="prefix" select="'sub'"/>
 	      </xsl:apply-templates>
 	      <xsl:apply-templates select="current-group()" mode="copy"/>
 	    </xsl:element>

--- a/nlp-utils/break-detection/src/test/xprocspec/reshape.xprocspec
+++ b/nlp-utils/break-detection/src/test/xprocspec/reshape.xprocspec
@@ -14,6 +14,7 @@
       </p:output>
       <px:reshape name="generic">
 	<p:with-option name="can-contain-sentences" select="'address,author,notice,prodnote,sidebar,line,em,strong,dfn,kdb,code,samp,cite,abbr,acronym,sub,sup,span,bdo,q,p,doctitle,docauthor,levelhd,hd,h1,h2,h3,h4,h5,h6,dt,dd,li,lic,caption,th,td,bridgehead,byline,covertitle,epigraph,dateline'"/>
+	<p:with-option name="cannot-be-sentence-child" select="'linenum,epigraph'"/>
 	<p:with-option name="special-sentences" select="'pagenum,annoref,noteref,linenum'"/>
 	<p:with-option name="output-ns" select="'http://www.daisy.org/z3986/2005/dtbook/'"/>
 	<p:with-option name="output-word-tag" select="'w'"/>
@@ -572,6 +573,79 @@
 	    <sent><w><span attr="id">existing</span></w></sent>
   	  </p></level>
   	</dtbook>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="Sentence-unfriendly element 1">
+    <x:call step="px:reshape-testing-wrapper">
+      <x:input port="source">
+  	<x:document type="inline">
+  	  <dtbook>
+  	    <line>
+  	      <tmp:ss><tmp:ww>before</tmp:ww> <tmp:ww>text</tmp:ww> <linenum><tmp:ww>2</tmp:ww></linenum> <tmp:ww>after</tmp:ww> <tmp:ww>text</tmp:ww></tmp:ss>
+  	    </line>
+  	  </dtbook>
+        </x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="result" type="compare">
+      <x:document type="inline">
+	<dtbook>
+	  <line>
+	    <sent>
+	      <w>before</w>
+	      <w>text</w>
+	    </sent>
+	    <linenum>2</linenum>
+	    <sent>
+	      <w>after</w>
+	      <w>text</w>
+	    </sent>
+	  </line>
+	</dtbook>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="Sentence-unfriendly element 2">
+    <x:call step="px:reshape-testing-wrapper">
+      <x:input port="source">
+  	<x:document type="inline">
+  	  <dtbook>
+  	    <td>
+  	      <tmp:ss><tmp:ww>before</tmp:ww> <tmp:ww>text</tmp:ww> <epigraph><tmp:ww>inside</tmp:ww> <tmp:ww>epigraph</tmp:ww></epigraph> <tmp:ww>after</tmp:ww> <tmp:ww>text</tmp:ww></tmp:ss>
+  	    </td>
+  	  </dtbook>
+        </x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="result" type="compare">
+      <x:document type="inline">
+	<dtbook>
+	  <td>
+	    <sent>
+	      <w>before</w>
+	      <w>text</w>
+	    </sent>
+	    <epigraph>
+	      <sent>
+		<w>inside</w>
+		<w>epigraph</w>
+	      </sent>
+	    </epigraph>
+	    <sent>
+	      <w>after</w>
+	      <w>text</w>
+	    </sent>
+	  </td>
+	</dtbook>
       </x:document>
     </x:expect>
   </x:scenario>


### PR DESCRIPTION
- prevents us from inserting sentences under linenums, epigraphs and some others
- fixed bug that was inserting extra text around noterefs/pagenums